### PR TITLE
add support for new systemd ntp output

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function checkSystemd(cb) {
         if (err) {
             return cb(err, false);
         }
-        var match = /^\s*ntp enabled: (yes|no)\s*$/mi.exec(stdout);
+        var match = /^\s*ntp enabled|synchronized: (yes|no)\s*$/mi.exec(stdout);
         if (!match) {
             err = new Error("can't find 'ntp enabled:' line in timedatectl output");
             return cb(err, false);


### PR DESCRIPTION
On my machine the output of `timedatectl status` differs slightly and is not matched causing an error.
See https://github.com/ethereum/mist/issues/496 for more users that have this issue.

```
      Local time: Sat 2016-04-16 08:51:26 CEST
  Universal time: Sat 2016-04-16 06:51:26 UTC
        RTC time: Sat 2016-04-16 06:51:26
       Time zone: Europe/Amsterdam (CEST, +0200)
 Network time on: no
NTP synchronized: no
 RTC in local TZ: no
```
