### PR TITLE
Void linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,8 @@ function checkWindows(cb) {
 
 function checkNtpd(cb) {
     execFile("ps", ["-A", "-o", "command"], function (err, stdout) {
-        cb(err, /^\/(usr\/)?s?bin\/ntpd/m.test(stdout));
+        // ntpd -g -u ntpd:ntpd -n (on Void Linux) 
+        cb(err, /^(\/(usr\/)?s?bin\/|)ntpd/m.test(stdout));
     });
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "os-timesync",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Check whether NTP time sync is enabled in OS settings.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "os-timesync",
-  "version": "1.0.8",
+  "version": "1.0.7",
   "description": "Check whether NTP time sync is enabled in OS settings.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hi.
When installing the [ethereum wallet](https://github.com/ethereum/mist/releases/download/v0.8.9/Ethereum-Wallet-linux64-0-8-9.zip) on my [Void Linux](http://www.voidlinux.eu/) box I received an incorrect warning about ntp not running. I found that it uses this node module. Void Linux doesn't use systemd, and the way it's calling ntpd is slightly different.

```    
ps -A -o command
...
ntpd -g -u ntpd:ntpd -n
```
I modified the regex a bit so that it matches _either_ on your original regex, _or_ on `ntpd` without any path, and incremented the version number to 1.0.8.