### PR TITLE
support systemd >= 235

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ function checkSystemd(cb) {
         if (err) {
             return cb(err, false);
         }
-        var match = /^\s*(NTP enabled|Network time on): (yes|no)\s*$/mi.exec(stdout);
+        var match = /^\s*(NTP enabled|Network time on|System clock synchronized): (yes|no)\s*$/mi.exec(stdout);
         if (!match) {
             err = new Error("can't find 'NTP enabled:' or 'Network time on:' in timedatectl output");
             return cb(err, false);


### PR DESCRIPTION
The output format of `timedatectl status` changed again.

See: https://github.com/systemd/systemd/commit/3ec530a1890925efe347f739917dd4078c1b1942

Output on my Arch Linux setup:

```
juergen@samson:~ → timedatectl status
                      Local time: Sa 2017-12-02 11:10:13 CET
                  Universal time: Sa 2017-12-02 10:10:13 UTC
                        RTC time: Sa 2017-12-02 10:10:13
                       Time zone: Europe/Berlin (CET, +0100)
       System clock synchronized: yes
systemd-timesyncd.service active: yes
                 RTC in local TZ: no

```

This is also the cause, why [mist](https://github.com/ethereum/mist) complains `Deine Computeruhr ist nicht synchronisiert!` on startup even tough I use the `systemd` ntp client.