### PR TITLE
Update to support new timedatectl output

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,9 +53,9 @@ function checkSystemd(cb) {
         if (err) {
             return cb(err, false);
         }
-        var match = /^\s*(NTP enabled|Network time on): (yes|no)\s*$/mi.exec(stdout);
+        var match = /^\s*(NTP enabled|Network time on|System clock synchronized): (yes|no)\s*$/mi.exec(stdout);
         if (!match) {
-            err = new Error("can't find 'NTP enabled:' or 'Network time on:' in timedatectl output");
+            err = new Error("can't find 'NTP enabled:' or 'Network time on:' or 'System clock synchronized:' in timedatectl output");
             return cb(err, false);
         }
         cb(null, match[2].toString().toLowerCase() === "yes");


### PR DESCRIPTION
In systemd master the output of timedatectl has been updated to say "System clock synchronized" rather than "Network time on" or "NTP enabled". https://github.com/systemd/systemd/blob/master/src/timedate/timedatectl.c#L128

This change adds the new timedatectl output to the regular expression and the error message.